### PR TITLE
🔍️ Add meta tags for better SEO & discovery in search results

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,6 +10,35 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     {{hugo.Generator}}
+
+    {{/* Title meta tags */}}
+    <meta property="og:title" content="{{ .Title }} | {{ .Site.Title }}" />
+    <meta name="twitter:title" content="{{ .Title }} | {{ .Site.Title }}" />
+    <meta itemprop="name" content="{{ .Title }} | {{ .Site.Title }}" />
+    <meta name="application-name" content="{{ .Title }} | {{ .Site.Title }}" />
+    <meta property="og:site_name" content="docs.pirsch.io" />
+
+    {{/* Description meta tags */}}
+    <meta name="description" content="{{ .Params.description }} | {{ .Site.Title }}" />
+    <meta itemprop="description" content="{{ .Params.description }} | {{ .Site.Title }}" />
+    <meta property="og:description" content="{{ .Params.description }} | {{ .Site.Title }}" />
+    <meta name="twitter:description" content="{{ .Params.description }} | {{ .Site.Title }}" />
+
+    {{/* Link mata tags */}}
+    <link rel="canonical" href="{{ .Permalink }}" itemprop="url" /> 
+    <meta name="url" content="{{ .Permalink }}" />
+    <meta name="twitter:url" content="{{ .Permalink }}" /> 
+    <meta property="og:url" content="{{ .Permalink }}" />
+
+    {{/* Language mata tag */}}
+    <meta property="og:locale" content="en_US">
+
+    {{/* Time meta tag */}}
+    <meta property="og:updated_time" content={{ .Lastmod.Format "2006-01-02T15:04:05Z0700" | safeHTML }} />
+
+    {{/* Include sitemap for better crawling/indexing of the website */}}
+    <link rel="sitemap" type="application/xml" title="Sitemap" href="{{ .Site.BaseURL }}sitemap.xml" /> 
+
     <link rel="stylesheet" type="text/css" href="{{$css.RelPermalink}}" />
     <link rel="shortcut icon" type="image/png" href="{{.Site.BaseURL}}favicon.png" />
     <title>


### PR DESCRIPTION
## What does this PR do ?
It adds the meta tags to each page for better SEO & discovery in search results

## Which file does this PR modify ?
The partial `head`, located at `layouts/partials/head.html`

## What will be the final result after this PR is merged ?

Let's take the billing page for illustration. This is how the source of the billing page will look:


![source of the billing page](https://user-images.githubusercontent.com/68782815/125557797-f114ce27-c9a4-4cc9-b704-891fa21ea386.png)

Note: My Hugo server runs at `http://192.168.29.42:1313` instead of the usual `http://localhost:1313`. Anyways when the site is deployed this is going to be `baseurl`

## Other notes:
- I have enabled 'Allow edits by maintainers'
- Request to maintainers: It would be nice to have Vercel/Netlify integration with this repo so that a preview is generated for every PR
